### PR TITLE
Fix new worker global dates

### DIFF
--- a/gestor_absencies/models.py
+++ b/gestor_absencies/models.py
@@ -132,6 +132,24 @@ class Worker(AbstractUser):
                     updated_by=self
                 )
                 absence.save()
+
+            global_occurrence_list = SomEnergiaOccurrence.objects.filter(
+                absence__absence_type__global_date=True
+            ).distinct('start_time', 'end_time')
+
+            for global_occurrence in global_occurrence_list:
+                absence = SomEnergiaAbsence.objects.filter(
+                    worker__username=self.username,
+                    absence_type__id=global_occurrence.absence.absence_type.id
+                ).get()
+                occurrence = SomEnergiaOccurrence(
+                    created_by=self,
+                    updated_by=self,
+                    absence=absence,
+                    start_time=global_occurrence.start_time,
+                    end_time=global_occurrence.end_time
+                )
+                occurrence.save()
         else:
             super(Worker, self).save(*args, **kwargs)
 

--- a/gestor_absencies/tests/test_helper.py
+++ b/gestor_absencies/tests/test_helper.py
@@ -103,11 +103,11 @@ def create_occurrence(absence_type, worker, start_time, end_time, created_by=Non
     return occurrence
 
 
-def create_global_occurrence(start_time, end_time):
+def create_global_occurrence(name, start_time, end_time):
     workers = Worker.objects.all()
 
     global_occurrence = SomEnergiaAbsenceType(
-        name='Global date',
+        name=name,
         description='',
         spend_days=0,
         min_duration=1,

--- a/gestor_absencies/tests/test_occurrences.py
+++ b/gestor_absencies/tests/test_occurrences.py
@@ -76,6 +76,7 @@ class SomEnergiaOccurrenceSetupMixin(object):
         self.id_occurrence = self.test_occurrence.pk
 
         self.id_global_occurrence = create_global_occurrence(
+            'Global date',
             start_time=(datetime.datetime(datetime.datetime.now().year + 1, 1, 1)).replace(
                 hour=9, microsecond=0, minute=0, second=0
             ),
@@ -483,6 +484,35 @@ class SomEnergiaOccurrencePOSTTest(SomEnergiaOccurrenceSetupMixin, TestCase):
             absence__absence_type=self.id_absencetype
             ).count(),
             1
+        )
+
+    def test__post_global_date_generate_occurrences(self):
+
+        id_second_global_occurrence = create_global_occurrence(
+            'Test date',
+            start_time=(
+                datetime.datetime(datetime.datetime.now().year + 2, 1, 1)
+            ).replace(hour=9, microsecond=0, minute=0, second=0),
+            end_time=(
+                datetime.datetime(datetime.datetime.now().year + 2, 1, 1)
+            ).replace(hour=15, microsecond=0, minute=0, second=0)
+        )
+
+        self.client.login(username='admin', password='password')
+        response = self.client.get(
+            self.base_url, {'worker': [self.test_worker.pk]}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['count'], 2)
+        self.assertEqual(response.json()['next'], None)
+        self.assertEqual(response.json()['previous'], None)
+        self.assertEqual(
+            response.json()['results'][1]['absence_type'],
+            id_second_global_occurrence
+        )
+        self.assertEqual(
+            response.json()['results'][1]['worker'], self.test_worker.pk
         )
 
     def test__post_passade_occurrence(self):

--- a/gestor_absencies/tests/test_worker.py
+++ b/gestor_absencies/tests/test_worker.py
@@ -3,10 +3,12 @@ from os.path import join
 
 from django.test import TestCase
 from django.urls import reverse
-from gestor_absencies.models import Worker
+from gestor_absencies.models import (Worker, SomEnergiaAbsence,
+                                     SomEnergiaOccurrence)
 from gestor_absencies.tests.test_helper import (create_absencetype,
                                                 create_vacationpolicy,
-                                                create_worker)
+                                                create_worker,
+                                                create_global_occurrence)
 
 
 class AdminTest(TestCase):
@@ -448,6 +450,51 @@ class AdminTest(TestCase):
 
     def test__worker_put_set_modified_params(self):
         pass
+
+    def test__worker_post_update_with_global_dates(self):
+
+        id_global_occurrence = create_global_occurrence(
+            name="Test Global Ocurrence",
+            start_time=(
+                dt(dt.now().year + 1, 1, 1)
+            ).replace(hour=9, microsecond=0, minute=0, second=0),
+            end_time=(
+                dt(dt.now().year + 1, 1, 1)
+            ).replace(hour=15, microsecond=0, minute=0, second=0)
+        )
+
+        second_worker = create_worker(
+            username='new_worker', email='random@random.coop'
+        )
+        self.client.login(username='admin', password='password')
+        body = {
+            'username': 'new_worker',
+            'first_name': 'first_name',
+            'last_name': 'last_name',
+            'email': 'newmail@example.com'
+        }
+        response = self.client.put(
+            join(self.base_url, str(second_worker.pk)),
+            data=body,
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            len(SomEnergiaAbsence.objects.filter(
+                worker__username='new_worker',
+                absence_type__global_date=True
+            )),
+            1
+        )
+        self.assertEqual(
+            len(SomEnergiaOccurrence.objects.filter(
+                absence__worker__username='new_worker',
+                absence__absence_type__id=id_global_occurrence
+            )),
+            1
+        )
 
     def tearDown(self):
         self.test_worker.delete()

--- a/gestor_absencies/tests/test_worker.py
+++ b/gestor_absencies/tests/test_worker.py
@@ -4,7 +4,8 @@ from os.path import join
 from django.test import TestCase
 from django.urls import reverse
 from gestor_absencies.models import (Worker, SomEnergiaAbsence,
-                                     SomEnergiaOccurrence)
+                                     SomEnergiaOccurrence,
+                                     SomEnergiaAbsenceType)
 from gestor_absencies.tests.test_helper import (create_absencetype,
                                                 create_vacationpolicy,
                                                 create_worker,
@@ -463,35 +464,32 @@ class AdminTest(TestCase):
             ).replace(hour=15, microsecond=0, minute=0, second=0)
         )
 
-        second_worker = create_worker(
-            username='new_worker', email='random@random.coop'
-        )
-        self.client.login(username='admin', password='password')
         body = {
-            'username': 'new_worker',
-            'first_name': 'first_name',
-            'last_name': 'last_name',
-            'email': 'newmail@example.com'
+            'username': 'Peli',
+            'password': 'yalo',
+            'first_name': 'Pelayo',
+            'last_name': 'Manzano',
+            'email': 'newmail@example.com',
+            'vacation_policy': self.test_vacation_policy.pk
         }
-        response = self.client.put(
-            join(self.base_url, str(second_worker.pk)),
-            data=body,
-            content_type='application/json'
-        )
 
-        self.assertEqual(response.status_code, 200)
-
-        self.assertEqual(
-            len(SomEnergiaAbsence.objects.filter(
-                worker__username='new_worker',
-                absence_type__global_date=True
-            )),
-            1
+        self.client.login(username='admin', password='password')
+        response = self.client.post(
+            self.base_url, data=body
         )
+        self.assertEqual(response.status_code, 201)
+
+        worker = Worker.objects.filter(
+            username=response.json()['username']
+        ).get()
+        global_occurrence = SomEnergiaAbsenceType.objects.filter(
+            id=id_global_occurrence
+        ).get()
+
         self.assertEqual(
             len(SomEnergiaOccurrence.objects.filter(
-                absence__worker__username='new_worker',
-                absence__absence_type__id=id_global_occurrence
+                absence__worker=worker,
+                absence__absence_type=global_occurrence
             )),
             1
         )
@@ -508,34 +506,32 @@ class AdminTest(TestCase):
             ).replace(hour=15, microsecond=0, minute=0, second=0)
         )
 
-        second_worker = create_worker(
-            username='new_worker', email='random@random.coop'
-        )
-        self.client.login(username='admin', password='password')
         body = {
-            'username': 'new_worker',
-            'first_name': 'first_name',
-            'last_name': 'last_name',
-            'email': 'newmail@example.com'
+            'username': 'super_peli',
+            'password': 'yalo',
+            'first_name': 'Pelayo',
+            'last_name': 'Palmera',
+            'email': 'superpeli@example.com',
+            'vacation_policy': self.test_vacation_policy.pk
         }
-        response = self.client.put(
-            join(self.base_url, str(second_worker.pk)),
-            data=body,
-            content_type='application/json'
+
+        self.client.login(username='admin', password='password')
+        response = self.client.post(
+            self.base_url, data=body
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 201)
+
+        worker = Worker.objects.filter(
+            username=response.json()['username']
+        ).get()
+        global_occurrence = SomEnergiaAbsenceType.objects.filter(
+            id=id_global_occurrence
+        ).get()
 
         self.assertEqual(
-            len(SomEnergiaAbsence.objects.filter(
-                worker__username='new_worker',
-                absence_type__global_date=True
-            )),
-            1
-        )
-        self.assertEqual(
             len(SomEnergiaOccurrence.objects.filter(
-                absence__worker__username='new_worker',
-                absence__absence_type__id=id_global_occurrence
+                absence__worker=worker,
+                absence__absence_type=global_occurrence
             )),
             1
         )


### PR DESCRIPTION
## Content of PR:

### Fixing bug:
When an global occurrence date is generated all the workers ocurrences are updated. The problem appears when we create a new worker. This one does not have any of the created global occurrence dates.

### Proposed Solution:
When a worker is created, all the global occurrences are also created for this worker.

### Tests created:
- `test__post_global_date_generate_occurrences` in test_occurrences.py
- `test__worker_post_update_with_global_dates` in test_worker.py
- `test__worker_post_update_with_past_global_dates` in test_worker.py
