### PR TITLE
Add protected sensible data

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,9 +1,16 @@
 import os
-# import datetime
+import yaml
 
 BASE_DIR = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 )
+
+with open(os.path.join(BASE_DIR, 'config/settings/config.yaml')) as f:
+    config = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+WORKER_PROTECTED_FIELDS = config['worker_protected_fieds']
+WORKER_SENSITIVE_FIELDS = config['worker_sensitive_fields']
+
 
 # Application definition
 

--- a/config/settings/config.yaml.example
+++ b/config/settings/config.yaml.example
@@ -19,3 +19,6 @@ databases:
 
 whitelist:
   prod: ["element"]
+
+worker_protected_fieds: ['username', 'category', 'contract_date']
+worker_sensitive_fields: ['gender', 'category', 'contract_date']

--- a/gestor_absencies/serializers.py
+++ b/gestor_absencies/serializers.py
@@ -16,6 +16,9 @@ from .models import (CategoryChoices, GenderChoices, Member, SomEnergiaAbsence,
                      VacationPolicy, Worker)
 
 
+WORKER_SENSITIVE_FIELDS = ['gender', 'category', 'contract_date']
+
+
 class WorkerSerializer(serializers.HyperlinkedModelSerializer):
     email = serializers.EmailField(required=False)
     password = serializers.CharField(write_only=True, required=False)
@@ -49,6 +52,16 @@ class WorkerSerializer(serializers.HyperlinkedModelSerializer):
             'working_week',
             'vacation_policy'
         ]
+
+    @property
+    def _readable_fields(self):
+        is_superuser = self.context.get('is_superuser', False)
+        for field in self.fields.values():
+            user_can_see_field = is_superuser or \
+                field.source not in WORKER_SENSITIVE_FIELDS
+
+            if not field.write_only and user_can_see_field:
+                yield field
 
     def create(self, validated_data):
         """Create and return a new worker."""

--- a/gestor_absencies/serializers.py
+++ b/gestor_absencies/serializers.py
@@ -1,5 +1,6 @@
 import datetime
 from datetime import timedelta as td
+from django.conf import settings
 
 import dateutil.rrule as rrule
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -16,7 +17,7 @@ from .models import (CategoryChoices, GenderChoices, Member, SomEnergiaAbsence,
                      VacationPolicy, Worker)
 
 
-WORKER_SENSITIVE_FIELDS = ['gender', 'category', 'contract_date']
+WORKER_SENSITIVE_FIELDS = settings.WORKER_SENSITIVE_FIELDS
 
 
 class WorkerSerializer(serializers.HyperlinkedModelSerializer):

--- a/gestor_absencies/tests/test_worker.py
+++ b/gestor_absencies/tests/test_worker.py
@@ -251,11 +251,9 @@ class AdminTest(TestCase):
     def test__worker_can_update_her_profile__worker(self):
         self.client.login(username='username', password='password')
         body = {
-            'username': 'worker',
             'first_name': 'first_name',
             'last_name': 'last_name',
             'email': 'newmail@example.com',
-            'contract_date': dt(2019, 1, 1).strftime("%Y-%m-%dT%H:%M:%S"),
             'working_week': 32
         }
         response = self.client.put(
@@ -266,7 +264,7 @@ class AdminTest(TestCase):
         expected = {'first_name': 'first_name',
                     'last_name': 'last_name',
                     'email': 'newmail@example.com',
-                    'username': 'worker',
+                    'username': 'username',
                     'id': self.id_worker,
                     'holidays': '0.0',
                     'vacation_policy': None,
@@ -306,7 +304,6 @@ class AdminTest(TestCase):
     def test__worker_can_change_password__worker(self):
         self.client.login(username='username', password='password')
         body = {
-            'username': 'username',
             'password': 'newpassword'
         }
         response = self.client.put(

--- a/gestor_absencies/tests/test_worker.py
+++ b/gestor_absencies/tests/test_worker.py
@@ -171,9 +171,6 @@ class AdminTest(TestCase):
                          'last_name': 'last_name',
                          'username': 'username',
                          'holidays': '0.0',
-                         'gender': '',
-                         'category': '',
-                         'contract_date': dt(2018, 9, 1).strftime("%Y-%m-%dT%H:%M:%S"),
                          'vacation_policy': None,
                          'working_week': 40
                          },
@@ -183,9 +180,6 @@ class AdminTest(TestCase):
                          'last_name': 'last_name',
                          'username': 'admin',
                          'holidays': '0.0',
-                         'gender': '',
-                         'category': '',
-                         'contract_date': dt(2018, 9, 1).strftime("%Y-%m-%dT%H:%M:%S"),
                          'vacation_policy': None,
                          'working_week': 40
                          },
@@ -206,9 +200,6 @@ class AdminTest(TestCase):
                     'username': 'username',
                     'id': self.id_worker,
                     'holidays': '0.0',
-                    'gender': '',
-                    'category': '',
-                    'contract_date': dt(2018, 9, 1).strftime("%Y-%m-%dT%H:%M:%S"),
                     'vacation_policy': None,
                     'working_week': 40
                     }
@@ -307,9 +298,6 @@ class AdminTest(TestCase):
             'username': 'username',
             'id': self.id_worker,
             'holidays': '0.0',
-            'gender': '',
-            'category': '',
-            'contract_date': dt(2018, 9, 1).strftime("%Y-%m-%dT%H:%M:%S"),
             'vacation_policy': None,
             'working_week': 40
         }

--- a/gestor_absencies/views.py
+++ b/gestor_absencies/views.py
@@ -21,6 +21,7 @@ from .serializers import (
     VacationPolicySerializer
 )
 from django.shortcuts import get_object_or_404
+from django.conf import settings
 from rest_framework.response import Response
 from rest_framework import status
 from django.core.exceptions import ValidationError
@@ -32,7 +33,7 @@ from rest_framework.exceptions import PermissionDenied
 logger = logging.getLogger(__name__)
 
 
-WORKER_PROTECTED_FIELDS = ['username', 'category', 'contract_date']
+WORKER_PROTECTED_FIELDS = settings.WORKER_PROTECTED_FIELDS
 
 
 class WorkerViewSet(viewsets.ModelViewSet):

--- a/gestor_absencies/views.py
+++ b/gestor_absencies/views.py
@@ -36,6 +36,11 @@ class WorkerViewSet(viewsets.ModelViewSet):
     queryset = Worker.objects.all().order_by('id')
     serializer_class = WorkerSerializer
 
+    def get_serializer_context(self):
+        context = super(WorkerViewSet, self).get_serializer_context()
+        context.update({'is_superuser': self.request.user.is_superuser})
+        return context
+
     def perform_create(self, serializer):
         if self.request.user.is_superuser:
             serializer.save()


### PR DESCRIPTION
# **Changes**
* Endpoint `/workers` only return `gender`, `category` and `contract_date` if requester is superuser
* Add `username`, `category` and `contract_date` to `WORKER_PROTECTED_FIELDS`. These fields can only be updated by the administrator

# **Tests**
* Only the necessary for this enhancement